### PR TITLE
feat: support deb822 format in Ubuntu 24.04

### DIFF
--- a/src/mirrors/ubuntu.sh
+++ b/src/mirrors/ubuntu.sh
@@ -3,8 +3,15 @@ check() {
 	[ "$NAME" = "Ubuntu" ]
 }
 
+_ubuntu_set_config_file() {
+	config_file="/etc/apt/sources.list.d/ubuntu.sources"
+	if ! [ -f $config_file ]; then # rule for ubuntu before 24.04
+		config_file="/etc/apt/sources.list"
+	fi
+}
+
 install() {
-	config_file="/etc/apt/sources.list"
+	_ubuntu_set_config_file
 	source_os_release
 	codename=${VERSION_CODENAME}
 	set_sudo
@@ -26,7 +33,48 @@ install() {
 	confirm "Use source code?" && \
 		src_prefix=""
 
-	$sudo sh -e -c "cat <<EOF > ${config_file}
+	# 如果 config_file == /etc/apt/sources.list.d/ubuntu.sources
+	if [ "$config_file" = "/etc/apt/sources.list.d/ubuntu.sources" ]; then
+		$sudo sh -e -c  "cat <<EOF > ${config_file}
+# ${gen_tag}
+Types: deb
+URIs: ${http}://${domain}/ubuntu/
+Suites: ${codename} ${codename}-updates ${codename}-backports
+Components: main universe restricted multiverse
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+${src_prefix}Types: deb-src
+${src_prefix}URIs: ${http}://${domain}/ubuntu/
+${src_prefix}Suites: ${codename} ${codename}-updates ${codename}-backports
+${src_prefix}Components: main universe restricted multiverse
+${src_prefix}Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+Types: deb
+URIs: ${secure_url}
+Suites: ${codename}-security
+Components: main universe restricted multiverse
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+${src_prefix}Types: deb-src
+${src_prefix}URIs: ${secure_url}
+${src_prefix}Suites: ${codename}-security
+${src_prefix}Components: main universe restricted multiverse
+${src_prefix}Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+${propoesd_prefix}Types: deb
+${propoesd_prefix}URIs: ${http}://${domain}/ubuntu/
+${propoesd_prefix}Suites: ${codename}-proposed
+${propoesd_prefix}Components: main universe restricted multiverse
+${propoesd_prefix}Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+${propoesd_prefix}Types: deb-src
+${propoesd_prefix}URIs: ${http}://${domain}/ubuntu/
+${propoesd_prefix}Suites: ${codename}-proposed
+${propoesd_prefix}Components: main universe restricted multiverse
+${propoesd_prefix}Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+EOF"
+	else
+		$sudo sh -e -c  "cat <<EOF > ${config_file}
 # ${gen_tag}
 deb ${http}://${domain}/ubuntu/ ${codename} main restricted universe multiverse
 ${src_prefix}deb-src ${http}://${domain}/ubuntu/ ${codename} main restricted universe multiverse
@@ -40,10 +88,13 @@ ${src_prefix}deb-src ${secure_url} ${codename}-security main restricted universe
 
 ${propoesd_prefix}deb ${http}://${domain}/ubuntu/ ${codename}-proposed main restricted universe multiverse
 ${propoesd_prefix}deb-src ${http}://${domain}/ubuntu/ ${codename}-proposed main restricted universe multiverse
-EOF" || {
+EOF"
+	fi
+
+	if [ $? -ne 0 ]; then
 		print_error "Write ${config_file} failed"
 		return 1
-	}
+	fi
 
 	confirm_y "Do you want to apt update?" && {
 		$sudo apt update || {
@@ -56,7 +107,7 @@ EOF" || {
 }
 
 uninstall() {
-	config_file="/etc/apt/sources.list"
+	_ubuntu_set_config_file
 	set_sudo
 	$sudo mv ${config_file}.bak ${config_file} || {
 		print_error "Failed to recover ${config_file}"
@@ -65,14 +116,16 @@ uninstall() {
 }
 
 is_deployed() {
-	config_file="/etc/apt/sources.list"
+	_ubuntu_set_config_file
 	result=0
 	$sudo grep -q "${gen_tag}" ${config_file} || result=$?
 	return $result
 }
 
 can_recover() {
-	bak_file="/etc/apt/sources.list.bak"
+	_ubuntu_set_config_file
+	bak_file="$config_file.bak"
+
 	result=0
 	test -f $bak_file || result=$?
 	return $result


### PR DESCRIPTION
This PR tries to add support for Ubuntu 24.04, which adopts `deb822-formatted` .source file.

cc #9 