### PR TITLE
feat: add rocky linux support

### DIFF
--- a/src/mirrors/rocky.sh
+++ b/src/mirrors/rocky.sh
@@ -19,13 +19,14 @@ install() {
 		}
 	done
 
-	$sudo sed -e 's|^mirrorlist=|#mirrorlist=|g' \
-		-e "s|^#baseurl=http://dl.rockylinux.org/\$contentdir|baseurl=${http}://${domain}/rocky|g" \
-		-i \
-		$config_pattern || {
-		print_error "Failed to modify Rocky repos"
-		return 1
-	}
+    $sudo sed -e 's|^mirrorlist=|#mirrorlist=|g' \
+        -e "s|^#*baseurl=https://[^/]*/rocky|baseurl=${http}://${domain}/rocky|g" \
+        -e "s|^#*baseurl=http://dl.rockylinux.org|baseurl=${http}://${domain}/rocky|g" \
+        -i \
+        $config_pattern || {
+        print_error "Failed to modify Rocky repos"
+        return 1
+    }
 
 	for file in $config_pattern; do
 		[ -f "$file" ] || continue

--- a/src/mirrors/rocky.sh
+++ b/src/mirrors/rocky.sh
@@ -1,0 +1,95 @@
+check() {
+	source_os_release
+	[ "$NAME" = "Rocky Linux" ]
+}
+
+install() {
+	source_os_release
+	set_sudo
+
+	config_pattern="/etc/yum.repos.d/[Rr]ocky*.repo"
+	
+	print_info "Changing Rocky Linux repositories to ${domain}..."
+	
+	for file in $config_pattern; do
+		[ -f "$file" ] || continue
+		$sudo cp "$file" "${file}.bak" || {
+			print_error "Failed to backup $file"
+			return 1
+		}
+	done
+
+	$sudo sed -e 's|^mirrorlist=|#mirrorlist=|g' \
+		-e "s|^#baseurl=http://dl.rockylinux.org/\$contentdir|baseurl=${http}://${domain}/rocky|g" \
+		-i \
+		$config_pattern || {
+		print_error "Failed to modify Rocky repos"
+		return 1
+	}
+
+	for file in $config_pattern; do
+		[ -f "$file" ] || continue
+		$sudo sed -i "1i# ${gen_tag}" "$file"
+	done
+
+	print_success "Rocky Linux repositories changed to ${domain}"
+
+	confirm_y "Do you want to clean cache and makecache?" && {
+		$sudo dnf clean all 2>/dev/null || $sudo yum clean all
+		$sudo rm -rf /var/cache/dnf /var/cache/yum
+		$sudo dnf makecache 2>/dev/null || $sudo yum makecache || {
+			print_error "makecache failed"
+			return 1
+		}
+		print_success "Cache updated successfully"
+	}
+
+	true
+}
+
+uninstall() {
+	config_pattern="/etc/yum.repos.d/[Rr]ocky*.repo"
+	set_sudo
+	
+	print_info "Recovering Rocky Linux repositories..."
+	
+	recovered=0
+	for file in $config_pattern; do
+		bak_file="${file}.bak"
+		if [ -f "$bak_file" ]; then
+			$sudo mv "$bak_file" "$file" || {
+				print_error "Failed to recover $file"
+				return 1
+			}
+			recovered=1
+		fi
+	done
+
+	if [ $recovered -eq 1 ]; then
+		print_success "Rocky Linux repositories recovered"
+	else
+		print_warning "No Rocky Linux backup files found"
+	fi
+
+	true
+}
+
+is_deployed() {
+	config_file="/etc/yum.repos.d/rocky.repo"
+	[ ! -f "$config_file" ] && config_file="/etc/yum.repos.d/Rocky.repo"
+	
+	[ ! -f "$config_file" ] && return 1
+	
+	result=0
+	grep -q "${gen_tag}" "$config_file" 2>/dev/null || result=$?
+	return $result
+}
+
+can_recover() {
+	for file in /etc/yum.repos.d/[Rr]ocky*.repo.bak; do
+		[ -f "$file" ] && return 0
+	done
+	return 1
+}
+
+# vim: set filetype=sh ts=4 sw=4 noexpandtab:

--- a/src/mirrors/rocky.sh
+++ b/src/mirrors/rocky.sh
@@ -19,14 +19,14 @@ install() {
 		}
 	done
 
-    $sudo sed -e 's|^mirrorlist=|#mirrorlist=|g' \
-        -e "s|^#*baseurl=https://[^/]*/rocky|baseurl=${http}://${domain}/rocky|g" \
-        -e "s|^#*baseurl=http://dl.rockylinux.org|baseurl=${http}://${domain}/rocky|g" \
-        -i \
-        $config_pattern || {
-        print_error "Failed to modify Rocky repos"
-        return 1
-    }
+	$sudo sed -e 's|^mirrorlist=|#mirrorlist=|g' \
+		-e 's|^#*baseurl=http://dl.rockylinux.org/\$contentdir/\$releasever|baseurl='"${http}://${domain}/rocky/\$releasever"'|g' \
+		-e 's|^#*baseurl=https://dl.rockylinux.org/\$contentdir/\$releasever|baseurl='"${http}://${domain}/rocky/\$releasever"'|g' \
+		-i \
+		$config_pattern || {
+		print_error "Failed to modify Rocky repos"
+		return 1
+	}
 
 	for file in $config_pattern; do
 		[ -f "$file" ] || continue

--- a/src/mirrors/rocky.sh
+++ b/src/mirrors/rocky.sh
@@ -19,14 +19,23 @@ install() {
 		}
 	done
 
-	$sudo sed -e 's|^mirrorlist=|#mirrorlist=|g' \
-		-e 's|^#*baseurl=http://dl.rockylinux.org/\$contentdir/\$releasever|baseurl='"${http}://${domain}/rocky/\$releasever"'|g' \
-		-e 's|^#*baseurl=https://dl.rockylinux.org/\$contentdir/\$releasever|baseurl='"${http}://${domain}/rocky/\$releasever"'|g' \
-		-i \
-		$config_pattern || {
-		print_error "Failed to modify Rocky repos"
-		return 1
-	}
+	for file in $config_pattern; do
+		[ -f "$file" ] || continue
+		$sudo sed -i 's|^mirrorlist=|#mirrorlist=|g' "$file"
+	done
+
+	for file in $config_pattern; do
+		[ -f "$file" ] || continue
+		
+		$sudo sed -i \
+			-e 's|^#*baseurl=http://dl.rockylinux.org/\$contentdir/\$releasever|baseurl='"${http}://${domain}/rocky/\$releasever"'|g' \
+			-e 's|^#*baseurl=https://dl.rockylinux.org/\$contentdir/\$releasever|baseurl='"${http}://${domain}/rocky/\$releasever"'|g' \
+			"$file"
+		
+		$sudo sed -i -E \
+			's|^#*baseurl=https?://[^/]+/rocky/\$releasever/|baseurl='"${http}://${domain}"'/rocky/$releasever/|g' \
+			"$file"
+	done
 
 	for file in $config_pattern; do
 		[ -f "$file" ] || continue


### PR DESCRIPTION
Fix #31  

## 功能描述
添加Rocky Linux的镜像源支持。

## 变更内容
- 添加了 `scripts/rocky.sh` 脚本，用于将Rocky Linux的官方源替换为华科镜像源。
- 脚本功能包括：检查系统、备份原有源、替换镜像源、恢复原有源。

## 测试
在Rocky Linux 9.6上测试通过，能够成功换源并安装软件。
<img width="889" height="987" alt="b44452891b1735a5f4a1c4985403b1d2" src="https://github.com/user-attachments/assets/094a7c44-f87a-426b-99e5-bf158335d6bc" />
<img width="937" height="1137" alt="49266667e670a2e34ae8754474f0a569" src="https://github.com/user-attachments/assets/8266fbf4-6db2-4e47-a385-197e67b4565d" />
