### PR TITLE
Add OpenBSD mirror configuration support

### DIFF
--- a/src/mirrors/openbsd.sh
+++ b/src/mirrors/openbsd.sh
@@ -1,0 +1,61 @@
+# OpenBSD mirror configuration script
+# Mirror ID: openbsd
+
+check() {
+	[ "$(uname -s)" = "OpenBSD" ]
+}
+
+_openbsd_install_1() {
+	# 一键替换 OpenBSD 软件源（/etc/installurl）
+	set_sudo
+
+	if [ -f /etc/installurl ]; then
+		mkdir -p ${_backup_dir} || {
+			print_error "Failed to create backup directory"
+			return 1
+		}
+		[ -f ${_backup_dir}/openbsd__etc_installurl.bak ] || $sudo cp /etc/installurl ${_backup_dir}/openbsd__etc_installurl.bak || {
+			print_error "Backup /etc/installurl failed"
+			return 1
+		}
+		printf '%s\n' "$http://$domain/OpenBSD" | $sudo tee /etc/installurl >/dev/null || {
+			print_error "Failed to update /etc/installurl"
+			return 1
+		}
+	else
+		print_warning "File /etc/installurl does not exist"
+	fi
+
+	return 0
+}
+
+install() {
+
+	_openbsd_install_1 || return 1
+	print_success "Mirror configuration updated successfully"
+}
+
+uninstall() {
+	# Recover from backup files and execute recovery commands
+	print_info "Starting recovery process..."
+
+	# Restore files from backup
+	if [ -f ${_backup_dir}/openbsd__etc_installurl.bak ]; then
+		set_sudo
+		$sudo cp "${_backup_dir}/openbsd__etc_installurl.bak" /etc/installurl 2>/dev/null || true
+		print_info "Restored /etc/installurl"
+	fi
+
+	print_success "Recovery completed"
+}
+
+can_recover() {
+	# Check if any backup files exist
+	[ -f ${_backup_dir}/openbsd__etc_installurl.bak ]
+}
+
+is_deployed() {
+	# Check if any replaced file contains domain variable
+	[ -f /etc/installurl ] && grep -q "$domain" /etc/installurl 2>/dev/null && return 0
+	return 1
+}


### PR DESCRIPTION
### 功能描述
添加OpenBSD镜像源配置支持

脚本实现了以下功能：

- **`check()`**: 检测是否为 OpenBSD 系统
- **`install()`**: 备份原配置并部署华科镜像源
- **`uninstall()`**: 从备份恢复原始配置
- **`is_deployed()`**: 检测镜像是否已部署
- **`can_recover()`**: 检测是否存在备份文件
### 变更内容
添加了openbsd.sh

### 测试内容
测试环境：
- **操作系统**: OpenBSD 7.8
- **架构**: amd64 (x86_64)
- **内核版本**: GENERIC#54

测试项 | 命令 | 结果
-- | -- | --
自动部署 | ./output/hustmirror-cli autodeploy | ✅ 成功
手动部署 | ./output/hustmirror-cli deploy openbsd | ✅ 成功
恢复配置 | ./output/hustmirror-cli recover openbsd | ✅ 成功
重复部署检测 | 再次 deploy 时提示已部署 | ✅ 成功
<img width="461" height="525" alt="image" src="https://github.com/user-attachments/assets/56310b63-5ea7-439e-bf66-96969cbdf458" />
